### PR TITLE
Feat/update to original mopo repo

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots verify -Pit

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target/
+/bin
+.project

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To try/use Mopo, add following dependency to your pom.xml (or to Gradle build):
     <dependency>
         <groupId>in.virit</groupId>
         <artifactId>mopo</artifactId>
-        <version>0.0.1</version> <!-- check latest version!! ->
+        <version>0.0.6</version> <!-- 0.0.6 or newer for Vaadin 25+, 0.0.5 is the last for v24 series at this point ->
         <scope>test</scope>
     </dependency>
 

--- a/documentation.md
+++ b/documentation.md
@@ -1,0 +1,201 @@
+# Mopo Documentation
+
+Mopo is a small helper library to make testing Vaadin applications with Microsoft Playwright easier from Java. 
+It provides Page Object helpers for complex Vaadin components (Grid, Date Picker, Date Time Picker, Combo Box) and 
+a set of utility methods to interact with Vaadin-specific client/server behavior.
+
+For installation and a short intro, see README.md. This document focuses on practical examples taken directly from the 
+integration tests in this repository.
+
+## Utilities: Mopo
+
+Mopo provides utilities around Playwright and Vaadin, such as:
+- waitForConnectionToSettle(): waits for Vaadin client/server requests to settle
+- click(Locator)/click(String): reliable clicking helper
+- trackClientSideErrors(), getClientSideErrors(), failOnClientSideErrors(): console error tracking helpers
+- assertNoJsErrors(): asserts dev tools shows no JS errors (when available in dev mode)
+- getViewsReportedByDevMode(): list available routes reported by Vaadin DevTools
+- driveIn(): execute code in the context of an element/shadow root
+
+Example usage (from AddonHelpersIT):
+
+```java
+// Track JS console errors and ensure page stays clean
+mopo.trackClientSideErrors();
+page.navigate("http://localhost:" + port + "/addonhelpers");
+
+mopo.waitForConnectionToSettle();
+
+mopo.getClientSideErrors().clear(); // clear expected favicon warning
+
+Assertions.assertEquals(0, mopo.getClientSideErrors().size(),
+    "There should be no console errors after the page has loaded");
+
+// Trigger an exception on purpose and fail the test if there are errors
+page.getByText("Throw JS exception").click();
+boolean thrown = false;
+try {
+    mopo.failOnClientSideErrors();
+} catch (RuntimeException e) {
+    thrown = true;
+}
+Assertions.assertTrue(thrown, "There should be an exception thrown");
+```
+
+List routes from Vaadin DevTools (dev mode):
+
+```java
+List<String> developmentTimeViewNames = mopo.getViewsReportedByDevMode(browser, "http://localhost:" + port + "/");
+developmentTimeViewNames.forEach(System.out::println);
+```
+
+Tip: When using inputs whose value is updated with server round-trips or lazy value-changed listeners, prefer calling 
+`mopo.waitForConnectionToSettle()` before asserting.
+
+## Grid: GridPw
+
+GridPw wraps vaadin-grid to provide convenient methods:
+- getRenderedRowCount()
+- getFirstVisibleRowIndex(), getLastVisibleRowIndex()
+- scrollToIndex(int)
+- selectRow(int)
+- getRow(int).getCell(int | String headerText)
+- RowPw.select()
+
+Example (adapted from GridPlaywrightIT):
+
+```java
+page.navigate("http://localhost:" + port + "/grid");
+GridPw grid = new GridPw(page);
+
+// Basic scrolling API
+assertEquals(0, grid.getFirstVisibleRowIndex());
+grid.scrollToIndex(10);
+assertEquals(10, grid.getFirstVisibleRowIndex());
+grid.scrollToIndex(0);
+
+// Select first row and edit via a form bound to selection
+String originalFirstName = grid.getRow(0).getCell(0).textContent();
+grid.getRow(0).select();
+
+// Update the "First name" field in the edit form
+String newFirstName = originalFirstName + "_changed0";
+page.getByLabel("First name", new Page.GetByLabelOptions().setExact(true)).fill(newFirstName);
+page.getByText("Save").click();
+
+mopo.waitForConnectionToSettle();
+
+// Verify via both index and header
+assertThat(grid.getRow(0).getCell(0)).hasText(newFirstName);
+assertThat(grid.getRow(0).getCell("First Name")).hasText(newFirstName);
+```
+
+Filtering example showing lazy server round-trips:
+
+```java
+page.getByPlaceholder("Filter by name...").locator("input").fill("Alice");
+// Filter input has lazy value change listener
+mopo.waitForConnectionToSettle();
+assertEquals(1, grid.getRenderedRowCount());
+```
+
+## Date Picker: DatePickerPw
+
+DatePickerPw helps reading/writing values of vaadin-date-picker using LocalDate.
+- getValue(): LocalDate (returns null if field is empty or unparsable)
+- setValue(LocalDate)
+- getInputString(): raw input value as string (locale formatted)
+
+Example (from DatePickerIT):
+
+```java
+page.navigate("http://localhost:" + port + "/date");
+DatePickerPw datePickerPw = new DatePickerPw(page.locator("#dp"));
+
+LocalDate localDate = LocalDate.of(2001, 12, 24);
+assertNull(datePickerPw.getValue());
+
+datePickerPw.setValue(localDate);
+assertEquals(localDate, datePickerPw.getValue());
+assertThat(page.locator("#dpValue")).containsText(localDate.toString());
+
+// The view has a button that sets the date to now on the server
+LocalDate now = LocalDate.now();
+mopo.click(page.getByText("set now"));
+String valueInField = datePickerPw.getInputString();
+String formattedNow = DateTimeFormatter.ofPattern("M/d/yyyy", Locale.US).format(now);
+assertEquals(formattedNow, valueInField);
+assertThat(page.locator("#dpValue")).containsText(now.toString());
+```
+
+## Date Time Picker: DateTimePickerPw
+
+DateTimePickerPw (see source for methods) provides helpers for vaadin-date-time-picker, including reading the separate 
+date and time inputs as strings formatted according to locale.
+
+Example (from DatePickerIT):
+
+```java
+DateTimePickerPw dateTimePickerPw = new DateTimePickerPw(page.locator("#dtp"));
+LocalDateTime localDateTime = LocalDateTime.of(2001,12,24,22,36,0,0);
+
+dateTimePickerPw.setValue(localDateTime);
+assertThat(page.locator("#dtpValue")).containsText(localDateTime.toString());
+
+String dateInputValue = dateTimePickerPw.getDateInputString();
+String timeInputValue = dateTimePickerPw.getTimeInputString();
+assertEquals("12/24/2001", dateInputValue);
+assertEquals("10:36:00 PM", timeInputValue);
+```
+
+## Combo Box: ComboBoxPw
+
+ComboBoxPw offers convenience around vaadin-combo-box:
+- filter(String)
+- filterAndSelectFirst(String)
+- selectOption(String)
+- openDropDown(): Locator
+- selectionDropdown(): Locator
+
+Example usage (from ComboBoxIT):
+
+```java
+page.navigate("http://localhost:" + port + "/combobox");
+
+ComboBoxPw cbPw = new ComboBoxPw(page.locator("vaadin-combo-box"));
+Locator value = page.locator("#value");
+
+// Type filter and pick first suggestion
+cbPw.filterAndSelectFirst("foo");
+assertThat(value).containsText("foo");
+
+// Type partial and select a specific option from the overlay
+cbPw.filter("ba").selectOption("baz");
+assertThat(value).containsText("baz");
+
+// Open dropdown via toggle and click an option
+cbPw.openDropDown().getByText("foo").click();
+assertThat(value).containsText("foo");
+```
+
+Raw Playwright example (no helper) for comparison:
+
+```java
+Locator cb = page.locator("input[role='combobox']");
+cb.fill("foo");
+page.waitForTimeout(1000); // sometimes needed with newer Vaadin versions
+cb.press("Enter");
+```
+
+## Tips
+
+- Prefer locating by ids or labels where possible: `page.getByLabel("First name", new Page.GetByLabelOptions().setExact(true))`.
+- Vaadin components often update state via server round-trips. After interactions that trigger server-side logic, use `mopo.waitForConnectionToSettle()` before asserting.
+- For combo box suggestions, ensure the overlay is visible and skip hidden duplicates: `vaadin-combo-box-item:not([hidden])`.
+- Use Mopo.click() wrapper to avoid flakiness with certain shadow DOM elements.
+
+## References
+
+- Source helpers: src/main/java/in/virit/mopo/
+- Integration tests with examples: src/test/java/firitin/pw/
+- README: README.md

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <description>Java Playwright helpers for Vaadin users</description>
 
     <properties>
-        <vaadin.version>24.3.5</vaadin.version>
+        <vaadin.version>24.8.4</vaadin.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -42,17 +42,6 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -177,9 +166,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>3.1.1</version>
                 <configuration>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <useReleaseProfile>false</useReleaseProfile>
                     <releaseProfiles>release</releaseProfiles>
+                    <goals>deploy</goals>
                 </configuration>
             </plugin>
 
@@ -191,20 +183,19 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.6.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
                         </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>flatten-maven-plugin</artifactId>
-                        <version>1.2.5</version>
+                        <version>1.7.0</version>
                         <configuration>
                             <flattenMode>oss</flattenMode>
                         </configuration>
@@ -227,8 +218,34 @@
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.3.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.7.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.2.7</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>in.virit</groupId>
     <artifactId>mopo</artifactId>
-    <version>0.0.5-SNAPSHOT</version>
+    <version>0.0.5</version>
     <name>Mopo</name>
     <packaging>jar</packaging>
     <description>Java Playwright helpers for Vaadin users</description>
@@ -28,7 +28,7 @@
         <url>https://github.com/viritin/mopo</url>
         <connection>scm:git:git://github.com/viritin/mopo.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:/viritin/mopo.git</developerConnection>
-      <tag>HEAD</tag>
+      <tag>mopo-0.0.5</tag>
   </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>in.virit</groupId>
     <artifactId>mopo</artifactId>
-    <version>0.0.4</version>
+    <version>0.0.5-SNAPSHOT</version>
     <name>Mopo</name>
     <packaging>jar</packaging>
     <description>Java Playwright helpers for Vaadin users</description>
@@ -28,7 +28,7 @@
         <url>https://github.com/viritin/mopo</url>
         <connection>scm:git:git://github.com/viritin/mopo.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:/viritin/mopo.git</developerConnection>
-      <tag>mopo-0.0.4</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>in.virit</groupId>
     <artifactId>mopo</artifactId>
-    <version>0.0.5</version>
+    <version>0.0.6-SNAPSHOT</version>
     <name>Mopo</name>
     <packaging>jar</packaging>
     <description>Java Playwright helpers for Vaadin users</description>
@@ -28,7 +28,7 @@
         <url>https://github.com/viritin/mopo</url>
         <connection>scm:git:git://github.com/viritin/mopo.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:/viritin/mopo.git</developerConnection>
-      <tag>mopo-0.0.5</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.microsoft.playwright</groupId>
             <artifactId>playwright</artifactId>
-            <version>1.44.0</version> <!-- Check the latest version via https://playwright.dev -->
+            <version>1.53.0</version> <!-- Check the latest version via https://playwright.dev -->
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>in.virit</groupId>
     <artifactId>mopo</artifactId>
-    <version>0.0.4-SNAPSHOT</version>
+    <version>0.0.4</version>
     <name>Mopo</name>
     <packaging>jar</packaging>
     <description>Java Playwright helpers for Vaadin users</description>
@@ -28,7 +28,7 @@
         <url>https://github.com/viritin/mopo</url>
         <connection>scm:git:git://github.com/viritin/mopo.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:/viritin/mopo.git</developerConnection>
-      <tag>HEAD</tag>
+      <tag>mopo-0.0.4</tag>
   </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,13 @@
             <artifactId>vaadin-core</artifactId>
             <scope>test</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-spring-boot-starter</artifactId>
+            <!--version>24.3.0</!version--> 
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>com.vaadin</groupId>
@@ -82,7 +89,7 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>6.1.0</version>
+            <!--version>6.1.0</!version-->
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -131,6 +138,11 @@
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
                 <version>2.12.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <!--version>3.2.0</version--> 
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -340,4 +352,3 @@
         </profile>
     </profiles>
 </project>
-

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>in.virit</groupId>
     <artifactId>mopo</artifactId>
-    <version>0.0.6</version>
+    <version>0.0.7-SNAPSHOT</version>
     <name>Mopo</name>
     <packaging>jar</packaging>
     <description>Java Playwright helpers for Vaadin users</description>
@@ -27,7 +27,7 @@
         <url>https://github.com/viritin/mopo</url>
         <connection>scm:git:git://github.com/viritin/mopo.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:/viritin/mopo.git</developerConnection>
-      <tag>mopo-0.0.6</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>in.virit</groupId>
     <artifactId>mopo</artifactId>
-    <version>0.0.6-SNAPSHOT</version>
+    <version>0.0.6</version>
     <name>Mopo</name>
     <packaging>jar</packaging>
     <description>Java Playwright helpers for Vaadin users</description>
@@ -27,7 +27,7 @@
         <url>https://github.com/viritin/mopo</url>
         <connection>scm:git:git://github.com/viritin/mopo.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:/viritin/mopo.git</developerConnection>
-      <tag>HEAD</tag>
+      <tag>mopo-0.0.6</tag>
   </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,8 @@
     <description>Java Playwright helpers for Vaadin users</description>
 
     <properties>
-        <vaadin.version>24.8.4</vaadin.version>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <vaadin.version>25.0.0-beta7</vaadin.version>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -47,7 +46,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.10.2</version>
+                <version>5.14.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -65,24 +64,31 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.microsoft.playwright</groupId>
             <artifactId>playwright</artifactId>
-            <version>1.53.0</version> <!-- Check the latest version via https://playwright.dev -->
+            <version>1.56.0</version> <!-- Check the latest version via https://playwright.dev -->
         </dependency>
 
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>5.0.0</version>
+            <version>6.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.9.4</version>
+            <version>1.11.0</version>
             <scope>test</scope>
             <type>jar</type>
         </dependency>
@@ -90,7 +96,7 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>8.0.0.Final</version>
+            <version>9.1.0.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -185,7 +191,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.6.0</version>
+                        <version>0.9.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>

--- a/src/main/java/in/virit/mopo/ComboBoxPw.java
+++ b/src/main/java/in/virit/mopo/ComboBoxPw.java
@@ -28,7 +28,14 @@ public class ComboBoxPw {
      */
     public void filterAndSelectFirst(String filter) {
         filter(filter);
+
+        // seems to be needed with latest Vaadin versions
+        assertThat(root).not().hasAttribute("loading", "");
+
         root.locator("input").press("Enter");
+
+        // seems to be needed with latest Vaadin versions
+        assertThat(root).not().hasAttribute("opened", "");
     }
 
     /**

--- a/src/main/java/in/virit/mopo/ComboBoxPw.java
+++ b/src/main/java/in/virit/mopo/ComboBoxPw.java
@@ -1,7 +1,7 @@
 package in.virit.mopo;
 
 import com.microsoft.playwright.Locator;
-
+import java.util.List;
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 
 /**
@@ -36,6 +36,23 @@ public class ComboBoxPw {
 
         // seems to be needed with latest Vaadin versions
         assertThat(root).not().hasAttribute("opened", "");
+    }
+
+    /**
+     * Filters the MultiSelectComboBox by searching for each term provided in the filter 
+     * list and selects the first suggestion for each term.
+     *
+     * @param filterList a list of strings representing the terms to be searched 
+     * for and selected in the ComboBox
+     */
+    public void filterAndSelectFirstMultiSelect(List<String> filterList) {
+      root.locator("input").press("Escape");
+      for(String filter: filterList) {
+        filter(filter);
+        root.locator("input").press("Enter");
+        root.locator("input").press("Escape");
+      }
+        root.locator("input").press("Escape");
     }
 
     /**

--- a/src/main/java/in/virit/mopo/ComboBoxPw.java
+++ b/src/main/java/in/virit/mopo/ComboBoxPw.java
@@ -75,7 +75,7 @@ public class ComboBoxPw {
      */
     public Locator selectionDropdown() {
         // there can be only one
-        return root.page().locator("vaadin-combo-box-overlay");
+        return root.page().locator("vaadin-combo-box-scroller");
     }
 
     /**

--- a/src/main/java/in/virit/mopo/ComboBoxPw.java
+++ b/src/main/java/in/virit/mopo/ComboBoxPw.java
@@ -87,5 +87,14 @@ public class ComboBoxPw {
         root.locator("#toggleButton").click();
         return selectionDropdown();
     }
+    
+    /**
+     * Returns the selected value for the ComboBox
+     *  
+     * @return the selected value
+     */
+    public String getSelection() {
+      return root.locator("input").inputValue();
+    }
 
 }

--- a/src/main/java/in/virit/mopo/DatePickerPw.java
+++ b/src/main/java/in/virit/mopo/DatePickerPw.java
@@ -1,8 +1,9 @@
 package in.virit.mopo;
 
 import com.microsoft.playwright.Locator;
-
+import com.microsoft.playwright.Page;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 /**
  * A helper class to work with vaadin-date-picker component.
@@ -10,7 +11,22 @@ import java.time.LocalDate;
 public class DatePickerPw {
 
     private final Locator root;
+    private final Page page;
+    private String dateFormat;
 
+    /**
+     * Creates a DatePicker page object for the specified Page and element ID.
+     *
+     * @param page
+     *            The Page to which the date picker belongs.
+     * @param id
+     *            The ID of the date picker element.
+     */
+    public DatePickerPw(Page page, String id) {
+        this.page = page;
+        this.root = page.locator("#" + id + " > input");
+    }
+    
     /**
      * Creates a DatePicker page object for the given locator.
      *
@@ -19,6 +35,7 @@ public class DatePickerPw {
      */
     public DatePickerPw(Locator gridLocator) {
         this.root = gridLocator;
+        this.page = gridLocator.page();
     }
 
     /**
@@ -39,17 +56,37 @@ public class DatePickerPw {
     /**
      * Sets the value of the field.
      *
-     * @param value the value to be set
+     * @param value
+     *            the value to be set
      */
     public void setValue(LocalDate value) {
-        root.evaluate("db => db.value = '%s'".formatted(value));
+        String formattedDate = (dateFormat == null ? value.toString()
+                : DateTimeFormatter.ofPattern(dateFormat).format(value));
+
+        root.fill(formattedDate);
+        root.press("Enter");
+
+        // Wait for the date picker overlay to be hidden
+        Page.WaitForSelectorOptions options = new Page.WaitForSelectorOptions();
+        options.setState(options.state.HIDDEN);
+        page.waitForSelector("vaadin-date-picker-overlay", options);
+    }
+
+    /**
+     * Sets the format to be used when setting the date value.
+     *
+     * @param format
+     *            The format to be set.
+     */
+    public void setDateFormat(String format) {
+        dateFormat = format;
     }
 
     /**
      * Returns the raw string value in the field.
      *
      * @return the string value as it is formatted in the field. Note, this may
-     * be locale dependent.
+     *         be locale dependent.
      */
     public String getInputString() {
         return root.locator("input").inputValue();

--- a/src/main/java/in/virit/mopo/DatePickerPw.java
+++ b/src/main/java/in/virit/mopo/DatePickerPw.java
@@ -47,7 +47,7 @@ public class DatePickerPw {
     public LocalDate getValue() {
         String str = (String) root.evaluate("db => db.value");
         try {
-            return LocalDate.parse(str);
+            return LocalDate.parse(str, DateTimeFormatter.ofPattern(dateFormat));
         } catch (java.time.format.DateTimeParseException e) {
             return null;
         }

--- a/src/main/java/in/virit/mopo/DatePickerPw.java
+++ b/src/main/java/in/virit/mopo/DatePickerPw.java
@@ -1,9 +1,8 @@
 package in.virit.mopo;
 
-import com.microsoft.playwright.Locator;
-import com.microsoft.playwright.Page;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
+
+import com.microsoft.playwright.Locator;
 
 /**
  * A helper class to work with vaadin-date-picker component.
@@ -11,22 +10,7 @@ import java.time.format.DateTimeFormatter;
 public class DatePickerPw {
 
     private final Locator root;
-    private final Page page;
-    private String dateFormat;
 
-    /**
-     * Creates a DatePicker page object for the specified Page and element ID.
-     *
-     * @param page
-     *            The Page to which the date picker belongs.
-     * @param id
-     *            The ID of the date picker element.
-     */
-    public DatePickerPw(Page page, String id) {
-        this.page = page;
-        this.root = page.locator("#" + id + " > input");
-    }
-    
     /**
      * Creates a DatePicker page object for the given locator.
      *
@@ -35,7 +19,6 @@ public class DatePickerPw {
      */
     public DatePickerPw(Locator gridLocator) {
         this.root = gridLocator;
-        this.page = gridLocator.page();
     }
 
     /**
@@ -47,48 +30,27 @@ public class DatePickerPw {
     public LocalDate getValue() {
         String str = (String) root.evaluate("db => db.value");
         try {
-            return LocalDate.parse(str, DateTimeFormatter.ofPattern(dateFormat));
-        } catch (java.time.format.DateTimeParseException e) {
+      return LocalDate.parse(str);
+    } catch (java.time.format.DateTimeParseException e) {
             return null;
         }
     }
 
-    /**
-     * Sets the value of the field.
-     *
-     * @param value
-     *            the value to be set
-     */
-    public void setValue(LocalDate value) {
-        String formattedDate = (dateFormat == null ? value.toString()
-                : DateTimeFormatter.ofPattern(dateFormat).format(value));
-
-        root.fill(formattedDate);
-        root.press("Enter");
-
-        // Wait for the date picker overlay to be hidden
-        Page.WaitForSelectorOptions options = new Page.WaitForSelectorOptions();
-        options.setState(options.state.HIDDEN);
-        page.waitForSelector("vaadin-date-picker-overlay", options);
+  /**
+   * Sets the value of the field.
+   *
+   * @param value the value to be set
+   */
+  public void setValue(LocalDate value) {
+    root.evaluate("db => db.value = '%s'".formatted(value));
     }
 
-    /**
-     * Sets the format to be used when setting the date value.
-     *
-     * @param format
-     *            The format to be set.
-     */
-    public void setDateFormat(String format) {
-        dateFormat = format;
-    }
-
-    /**
-     * Returns the raw string value in the field.
-     *
-     * @return the string value as it is formatted in the field. Note, this may
-     *         be locale dependent.
-     */
-    public String getInputString() {
+  /**
+   * Returns the raw string value in the field.
+   *
+   * @return the string value as it is formatted in the field. Note, this may be locale dependent.
+   */
+  public String getInputString() {
         return root.locator("input").inputValue();
     }
 }

--- a/src/main/java/in/virit/mopo/DateTimePickerPw.java
+++ b/src/main/java/in/virit/mopo/DateTimePickerPw.java
@@ -28,6 +28,9 @@ public class DateTimePickerPw {
      */
     public void setValue(LocalDateTime value) {
         root.evaluate("db => db.value = '%s'".formatted(value));
+        // needed since 25...
+        root.evaluate("db => db.querySelector(\"input\").focus()");
+        root.evaluate("db => db.querySelector(\"input\").blur()");
     }
 
     /**

--- a/src/main/java/in/virit/mopo/GridPw.java
+++ b/src/main/java/in/virit/mopo/GridPw.java
@@ -179,9 +179,8 @@ public class GridPw {
          */
         public Locator getCell(int cellIndex) {
             int indexInVirtualTable = (Integer) root.evaluate("g => g._getRenderedRows().indexOf(g._getRenderedRows().filter(r => r.index == %s)[0]);".formatted(rowIndex));
-            indexInVirtualTable += 1; // 1-based :-)
-            String name = root.locator("#items tr:nth-child(%s) td:nth-child(%s) slot".formatted(indexInVirtualTable, cellIndex + 1))
-                    .getAttribute("name");
+            Locator row = root.locator("#items tr").filter(new Locator.FilterOptions().setVisible(true)).nth(indexInVirtualTable);
+            String name = row.locator("td:nth-child(%s) slot".formatted(cellIndex + 1)).getAttribute("name");
             return root.locator("vaadin-grid-cell-content[slot='%s']".formatted(name));
         }
 

--- a/src/main/java/in/virit/mopo/GridPw.java
+++ b/src/main/java/in/virit/mopo/GridPw.java
@@ -1,9 +1,10 @@
 package in.virit.mopo;
 
-import com.microsoft.playwright.Locator;
-import com.microsoft.playwright.Page;
 import java.util.ArrayList;
 import java.util.List;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
 
 /**
  * A helper class to work with the vaadin-grid component.
@@ -204,17 +205,20 @@ public class GridPw {
          * @return the cell locator
          */
         public Locator getCell(int cellIndex) {
-            int indexInVirtualTable = (Integer) root.evaluate(
-                    "g => g._getRenderedRows().indexOf(g._getRenderedRows().filter(r => r.index == %s)[0]);"
-                            .formatted(rowIndex));
-            indexInVirtualTable += 1; // 1-based :-)
-            String name = root
-                    .locator("#items tr:nth-child(%s) td:nth-child(%s) slot"
-                            .formatted(indexInVirtualTable, cellIndex + 1))
-                    .getAttribute("name");
-            return root.locator(
-                    "vaadin-grid-cell-content[slot='%s']".formatted(name));
+      int indexInVirtualTable =
+          (Integer)
+              root.evaluate(
+                  "g => g._getRenderedRows().indexOf(g._getRenderedRows().filter(r => r.index == %s)[0]);"
+                      .formatted(rowIndex));
+      Locator row =
+          root.locator("#items tr")
+              .filter(new Locator.FilterOptions().setVisible(true))
+              .nth(indexInVirtualTable);
+      String name =
+          row.locator("td:nth-child(%s) slot".formatted(cellIndex + 1)).getAttribute("name");
+      return root.locator("vaadin-grid-cell-content[slot='%s']".formatted(name));
         }
+
 
         /**
          * Gets the cell with the given header text.

--- a/src/main/java/in/virit/mopo/GridPw.java
+++ b/src/main/java/in/virit/mopo/GridPw.java
@@ -2,6 +2,8 @@ package in.virit.mopo;
 
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A helper class to work with the vaadin-grid component.
@@ -13,7 +15,8 @@ public class GridPw {
     /**
      * Creates a Grid page object for the given grid locator.
      *
-     * @param gridLocator the Playwright locator for the grid
+     * @param gridLocator
+     *            the Playwright locator for the grid
      */
     public GridPw(Locator gridLocator) {
         this.root = gridLocator;
@@ -22,7 +25,8 @@ public class GridPw {
     /**
      * Creates a Grid page object for the first grid on the page.
      *
-     * @param page the Playwright page
+     * @param page
+     *            the Playwright page
      */
     public GridPw(Page page) {
         this(page.locator("vaadin-grid"));
@@ -34,8 +38,22 @@ public class GridPw {
      * @return the number of rows
      */
     public int getRenderedRowCount() {
-        Integer evaluate = (Integer) root.elementHandle().evaluate("e => e._getRenderedRows().length");
+        Integer evaluate = (Integer) root.elementHandle()
+                .evaluate("e => e._getRenderedRows().length");
         return evaluate;
+    }
+
+    /**
+     * Returns a list of RowPw objects representing the grid rows.
+     *
+     * @return A List of RowPw objects representing the grid rows.
+     */
+    public List<RowPw> getGridRows() {
+        List<RowPw> allRows = new ArrayList<>();
+        for (int i = 0; i < getRenderedRowCount(); i++) {
+            allRows.add(getRow(i));
+        }
+        return allRows;
     }
 
     /**
@@ -44,68 +62,71 @@ public class GridPw {
      * @return the index.
      */
     public int getFirstVisibleRowIndex() {
-        return (Integer) root.elementHandle().evaluate("e => e._firstVisibleIndex");
+        return (Integer) root.elementHandle()
+                .evaluate("e => e._firstVisibleIndex");
     }
 
     /**
      * Scrolls the grid to the given index.
      *
-     * @param index the row index to scroll to
+     * @param index
+     *            the row index to scroll to
      */
     public void scrollToIndex(int index) {
         root.elementHandle().evaluate("e => e.scrollToIndex(" + index + ")");
 
         // FIXME this don't seem to be stable, but
         // 10*100ms timeout seems to do the trick most of the time
-        int value = (Integer) root.evaluate("""
-                g => {
-                    return new Promise((resolve, reject) => {
-                        var x = 0;
-                        const isDoneLoading = () => {
-                            return !g.$connector.hasRootRequestQueue()
-                        };
-                        
-                        const isVaadinConnectionActive = () => {
-                            if (window.Vaadin && window.Vaadin.Flow && window.Vaadin.Flow.clients) {
-                              var clients = window.Vaadin.Flow.clients;
-                              for (var client in clients) {
-                                if (clients[client].isActive()) {
-                                  return false;
+        int value = (Integer) root.evaluate(
+                """
+                        g => {
+                            return new Promise((resolve, reject) => {
+                                var x = 0;
+                                const isDoneLoading = () => {
+                                    return !g.$connector.hasRootRequestQueue()
+                                };
+
+                                const isVaadinConnectionActive = () => {
+                                    if (window.Vaadin && window.Vaadin.Flow && window.Vaadin.Flow.clients) {
+                                      var clients = window.Vaadin.Flow.clients;
+                                      for (var client in clients) {
+                                        if (clients[client].isActive()) {
+                                          return false;
+                                        }
+                                      }
+                                      return true;
+                                    } else if (window.Vaadin && window.Vaadin.Flow && window.Vaadin.Flow.devServerIsNotLoaded) {
+                                      return false;
+                                    } else {
+                                      return true;
+                                    }
+                                };
+
+                                if (isDoneLoading() && !isVaadinConnectionActive()) {
+                                    resolve(x);
+                                    return;
                                 }
-                              }
-                              return true;
-                            } else if (window.Vaadin && window.Vaadin.Flow && window.Vaadin.Flow.devServerIsNotLoaded) {
-                              return false;
-                            } else {
-                              return true;
-                            }
-                        };
-                        
-                        if (isDoneLoading() && !isVaadinConnectionActive()) {
-                            resolve(x);
-                            return;
-                        }
-                        
-                        var intervalID = window.setInterval(function () {
-                            if (isDoneLoading() && !isVaadinConnectionActive()) {
-                                window.clearInterval(intervalID);
-                                resolve(x+1);
-                            } else {
-                               if (++x === 10) {
-                                   window.clearInterval(intervalID);
-                                   resolve(-1);
-                               }
-                           }
-                        }, 100);
-                    });
-                }""");
-        // System.out.println("RETURN value = " + value);
+
+                                var intervalID = window.setInterval(function () {
+                                    if (isDoneLoading() && !isVaadinConnectionActive()) {
+                                        window.clearInterval(intervalID);
+                                        resolve(x+1);
+                                    } else {
+                                       if (++x === 10) {
+                                           window.clearInterval(intervalID);
+                                           resolve(-1);
+                                       }
+                                   }
+                                }, 100);
+                            });
+                        }""");
     }
 
     /**
      * Selects the given row.
      *
-     * @param rowIndex the row index to select
+     * @param rowIndex
+     *            the row index to select
      */
     public void selectRow(int rowIndex) {
         String script = """
@@ -117,16 +138,18 @@ public class GridPw {
                     var row = rows[0];
                     grid.activeItem = row._item;
                 }
-                """.formatted(rowIndex);
+                """
+                .formatted(rowIndex);
         root.elementHandle().evaluate(script);
     }
 
     /**
      * Returns a RowPw helper representing the row defined by the given index.
      *
-     * @param rowIndex the row index
+     * @param rowIndex
+     *            the row index
      * @return the RowPw for editing the UI state or to get cell locators for
-     * assertions.
+     *         assertions.
      */
     public RowPw getRow(int rowIndex) {
         if (!isRowInView(rowIndex)) {
@@ -138,9 +161,10 @@ public class GridPw {
     /**
      * Checks if the given row is in the visible viewport.
      *
-     * @param rowIndex the row to check
+     * @param rowIndex
+     *            the row to check
      * @return <code>true</code> if the row is at least partially in view,
-     * <code>false</code> otherwise
+     *         <code>false</code> otherwise
      */
     public boolean isRowInView(int rowIndex) {
         return (getFirstVisibleRowIndex() <= rowIndex
@@ -153,7 +177,8 @@ public class GridPw {
      * @return the index
      */
     public int getLastVisibleRowIndex() {
-        return (Integer) root.elementHandle().evaluate("e => e._lastVisibleIndex");
+        return (Integer) root.elementHandle()
+                .evaluate("e => e._lastVisibleIndex");
     }
 
     /**
@@ -172,22 +197,30 @@ public class GridPw {
         /**
          * Gets the cell locator at the given index.
          *
-         * @param cellIndex the cell index (0-based, unlike the CSS nth-child
-         * selector, whose designer should be hung by the balls, in case they
-         * have any)
+         * @param cellIndex
+         *            the cell index (0-based, unlike the CSS nth-child
+         *            selector, whose designer should be hung by the balls, in
+         *            case they have any)
          * @return the cell locator
          */
         public Locator getCell(int cellIndex) {
-            int indexInVirtualTable = (Integer) root.evaluate("g => g._getRenderedRows().indexOf(g._getRenderedRows().filter(r => r.index == %s)[0]);".formatted(rowIndex));
-            Locator row = root.locator("#items tr").filter(new Locator.FilterOptions().setVisible(true)).nth(indexInVirtualTable);
-            String name = row.locator("td:nth-child(%s) slot".formatted(cellIndex + 1)).getAttribute("name");
-            return root.locator("vaadin-grid-cell-content[slot='%s']".formatted(name));
+            int indexInVirtualTable = (Integer) root.evaluate(
+                    "g => g._getRenderedRows().indexOf(g._getRenderedRows().filter(r => r.index == %s)[0]);"
+                            .formatted(rowIndex));
+            indexInVirtualTable += 1; // 1-based :-)
+            String name = root
+                    .locator("#items tr:nth-child(%s) td:nth-child(%s) slot"
+                            .formatted(indexInVirtualTable, cellIndex + 1))
+                    .getAttribute("name");
+            return root.locator(
+                    "vaadin-grid-cell-content[slot='%s']".formatted(name));
         }
 
         /**
          * Gets the cell with the given header text.
          *
-         * @param headerText the header text
+         * @param headerText
+         *            the header text
          * @return the cell locator
          */
         public Locator getCell(String headerText) {

--- a/src/main/java/in/virit/mopo/Mopo.java
+++ b/src/main/java/in/virit/mopo/Mopo.java
@@ -90,14 +90,12 @@ public class Mopo {
     public void trackClientSideErrors() {
         page.waitForTimeout(1000);
         page.onConsoleMessage(msg -> {
-            System.out.println("Console message: " + msg.type() + " " + msg.text());
             if (msg.type().equals("error")) {
                 clientSideErrors.add(msg.text());
             }
         });
 
         page.onPageError(error -> {
-            System.out.println("Page error: " + error);
             clientSideErrors.add(error);
         });
     }

--- a/src/main/java/in/virit/mopo/TimePickerPw.java
+++ b/src/main/java/in/virit/mopo/TimePickerPw.java
@@ -2,9 +2,10 @@ package in.virit.mopo;
 
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
-
+import java.util.Locale;
 /**
  * A helper class to work with vaadin-time-picker component.
  */
@@ -38,7 +39,7 @@ public class TimePickerPw {
      */
     public void setValue(LocalTime value) {
         String formattedTime = (timeFormat == null ? value.toString()
-                : DateTimeFormatter.ofPattern(timeFormat).format(value));
+                : DateTimeFormatter.ofPattern(timeFormat, Locale.ROOT).format(value));
 
         root.fill(formattedTime);
         root.press("Enter");
@@ -47,6 +48,20 @@ public class TimePickerPw {
         Page.WaitForSelectorOptions options = new Page.WaitForSelectorOptions();
         options.setState(options.state.HIDDEN);
         page.waitForSelector("vaadin-time-picker-overlay", options);
+    }
+    
+    /**
+     * Returns the value from the client side and parses it as
+     * {@link LocalDate} using a {@link DateTimeFormatter}.
+     *
+     * @return the current value of the field
+     */
+    public LocalTime getValue() {
+        String value = root.inputValue();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(timeFormat, Locale.ROOT);
+        
+        return timeFormat == null ? LocalTime.parse(value)
+            : LocalTime.parse(value, formatter);
     }
 
     /**

--- a/src/main/java/in/virit/mopo/TimePickerPw.java
+++ b/src/main/java/in/virit/mopo/TimePickerPw.java
@@ -1,0 +1,62 @@
+package in.virit.mopo;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * A helper class to work with vaadin-time-picker component.
+ */
+public class TimePickerPw {
+
+    private final Locator root;
+    private final Page page;
+    private String timeFormat;
+
+    /**
+     * Constructs a TimePicker instance with the specified Page and element ID.
+     *
+     * @param page
+     *            The Page to which the time picker belongs.
+     * @param id
+     *            The ID of the time picker element.
+     */
+    public TimePickerPw(Page page, String id) {
+        this.page = page;
+        this.root = page.locator("#" + id + " > input");
+    }
+
+    /**
+     * Sets the value of the time picker to the specified LocalTime. The
+     * formatted time is entered into the input field, and "Enter" is pressed.
+     * Additionally, it waits for the time picker overlay to be hidden after
+     * setting the value.
+     *
+     * @param value
+     *            The LocalTime to be set.
+     */
+    public void setValue(LocalTime value) {
+        String formattedTime = (timeFormat == null ? value.toString()
+                : DateTimeFormatter.ofPattern(timeFormat).format(value));
+
+        root.fill(formattedTime);
+        root.press("Enter");
+
+        // Wait for the time picker overlay to be hidden
+        Page.WaitForSelectorOptions options = new Page.WaitForSelectorOptions();
+        options.setState(options.state.HIDDEN);
+        page.waitForSelector("vaadin-time-picker-overlay", options);
+    }
+
+    /**
+     * Sets the format to be used when setting the time value.
+     *
+     * @param format
+     *            The format to be set.
+     */
+    public void setDateFormat(String format) {
+        timeFormat = format;
+    }
+
+}

--- a/src/test/java/firitin/TestRunner.java
+++ b/src/test/java/firitin/TestRunner.java
@@ -1,0 +1,24 @@
+package firitin;
+import java.util.Collections;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+// This annotation tells Spring to start up and look for Views and AppShell
+@SpringBootApplication
+public class TestRunner {
+
+  public static void main(String[] args) {
+    // This launches the web server on localhost:9998
+    SpringApplication app = new SpringApplication(TestRunner.class);
+
+    // Force port 9998
+    app.setDefaultProperties(Collections.singletonMap("server.port", "9998"));
+
+    app.run(args);
+
+    System.out.println("----------------------------------------------");
+    System.out.println("  Test Server Running at http://localhost:9998");
+    System.out.println("----------------------------------------------");
+  }
+}

--- a/src/test/java/firitin/pw/ComboBoxIT.java
+++ b/src/test/java/firitin/pw/ComboBoxIT.java
@@ -59,6 +59,8 @@ public class ComboBoxIT {
         Locator cb = page.locator("input[role='combobox']");
 
         cb.fill("foo");
+        // seems to be needed with latest Vaadin versions
+        page.waitForTimeout(1000);
         cb.press("Enter");
 
         assertThat(value).containsText("foo");

--- a/src/test/java/firitin/pw/ComboBoxIT.java
+++ b/src/test/java/firitin/pw/ComboBoxIT.java
@@ -66,7 +66,7 @@ public class ComboBoxIT {
         assertThat(value).containsText("foo");
 
         cb.fill("ba");
-        Locator overlay = page.locator("vaadin-combo-box-overlay");
+        Locator overlay = page.locator("vaadin-combo-box-scroller");
         // this should be third option & visible
         overlay.getByText("baz").click();
 

--- a/src/test/java/firitin/pw/DatePickerIT.java
+++ b/src/test/java/firitin/pw/DatePickerIT.java
@@ -61,7 +61,7 @@ public class DatePickerIT {
 
         LocalDate localDate = LocalDate.of(2001,12,24);
 
-        DatePickerPw datePickerPw = new DatePickerPw(page.locator("#dp"));
+        DatePickerPw datePickerPw = new DatePickerPw(page, "dp");
 
         LocalDate value = datePickerPw.getValue();
         assertNull(value);

--- a/src/test/java/firitin/pw/DatePickerIT.java
+++ b/src/test/java/firitin/pw/DatePickerIT.java
@@ -61,7 +61,7 @@ public class DatePickerIT {
 
         LocalDate localDate = LocalDate.of(2001,12,24);
 
-        DatePickerPw datePickerPw = new DatePickerPw(page, "dp");
+        DatePickerPw datePickerPw = new DatePickerPw(page.locator("#dp"));
 
         LocalDate value = datePickerPw.getValue();
         assertNull(value);

--- a/src/test/java/firitin/pw/GridPlaywrightIT.java
+++ b/src/test/java/firitin/pw/GridPlaywrightIT.java
@@ -99,6 +99,11 @@ public class GridPlaywrightIT {
 
         // Get the first cell of the first row in Grid and check text
         // TODO add API to get cell by column header text
+        page.waitForTimeout(1000);
+        page.waitForTimeout(1000);
+
+        mopo.waitForConnectionToSettle();
+
         assertThat(grid.getRow(0).getCell(0)).hasText(newFirstName);
         assertThat(grid.getRow(0).getCell("First Name")).hasText(newFirstName);
 

--- a/src/test/java/firitin/ui/AddOnHelpersView.java
+++ b/src/test/java/firitin/ui/AddOnHelpersView.java
@@ -1,6 +1,7 @@
 package firitin.ui;
 
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
 
@@ -13,6 +14,7 @@ public class AddOnHelpersView extends VerticalLayout {
         add(new Button("Throw JS exception", e -> {
             // deliberately cause a JS exception
             getElement().executeJs("window.foo();");
+            add(new Paragraph("Error should have been thrown!"));
         }));
     }
 }

--- a/src/test/java/firitin/ui/AppShell.java
+++ b/src/test/java/firitin/ui/AppShell.java
@@ -1,9 +1,13 @@
 package firitin.ui;
 
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.component.page.Push;
+import com.vaadin.flow.theme.lumo.Lumo;
 
 @Push
+@StyleSheet(Lumo.STYLESHEET)
+@StyleSheet(Lumo.UTILITY_STYLESHEET)
 public class AppShell implements AppShellConfigurator {
     
 }


### PR DESCRIPTION
In order to stay up to date with the original repo, all changes were analyzed.

### Direct changes from original

- [Documentation file](documentation.md)
- Vaadin 25 support
- Java updated from 17 to 21
- Client side error monitoring in [Mopo class](src/main/java/in/virit/mopo/Mopo.java). Deprecation of assertNoJSErrors()
- Updated tests

### GridPW

- GridPw.scrollToIndex() differs a bit. However, tests run succesfully using both the original and fork versions
- GridPw.getGridRows() is a fork-specific method, so not present in tests

### Combobox

- Selection overlay is now located using "scroller" instead of overlay
- Multiselection is a fork-specific feature, so not present in tests


**Note**: [Dramafinder](https://github.com/parttio/dramafinder/tree/master/) also offers support for everything but Grid and Combobox. Besides support for many Vaadin elements, it also offers an abtract base IT class, among other features, like useful interfaces 


### DatePickerPW, DateTimePickerPW, TimePickerPW

### DatePickerPW

FC's version had:

-  dateFormat field(which had to be externally initialized)
-  Page field, constructor with page and id

Viritin's version was kept for this class. While dateFormat adds the feature of handling different formats, it causes issues when running tests. This is at least due to not being initialized, but there may be other issues. Besides, this changes do not match what is offered by DateTimePickerPW.

### TimePickerPW

- Has similar features to the ones discarded from DatePickerPW. 
- Is fork-specific, so not present in tests



### Additional features

- [TestRunner and dependencies](https://github.com/FlowingCode/mopo/commit/0bb37f616b94e4cdf971dc044094f80d9d8a951b) needed to boot the demo app and run tests.
